### PR TITLE
カテゴリー詳細の編集

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(document).on('turbolinks:load', ()=>{
+$(function() {
   //ヘッダーのカテゴリー表示
   function appendParentCategory(category){
     let html = `<a href="/categories/${category.id}" class="parent_nav_list" data-parent_id="${category.id}">${category.name}</a>`

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(function() {
+$(document).on('turbolinks:load', ()=>{
   //ヘッダーのカテゴリー表示
   function appendParentCategory(category){
     let html = `<a href="/categories/${category.id}" class="parent_nav_list" data-parent_id="${category.id}">${category.name}</a>`

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -9,8 +9,12 @@ class CategoriesController < ApplicationController
   end
 
   def show
-    @category = Category.find(params[:id])
-    @items = @category.items.where(status_id: 1)
+    @category = Category.find(params[:id])    
+    if @category.has_children?
+      @items = Item.where(status_id: 1, category_id: @category.descendant_ids.unshift(@category.id)) 
+    else
+      @items = @category.items.where(status_id: 1)
+    end
   end
 
   def get_category_children

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -17,9 +17,9 @@
       %tr
         %td.leftColumn カテゴリー
         %td.rightColumn
-          - if @item.category.parent.parent.name
+          - if @item.category.has_parent? && category.parent.has_parent?
             %div=link_to "#{@item.category.parent.parent.name}", category_path(@item.category.parent.parent.id)
-          - if @item.category.parent.name
+          - if @item.category.has_parent?
             %div=link_to "#{@item.category.parent.name}", category_path(@item.category.parent.id)
           %div=link_to "#{@item.category.name}", category_path(@item.category.id)
       %tr

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -17,7 +17,7 @@
       %tr
         %td.leftColumn カテゴリー
         %td.rightColumn
-          - if @item.category.has_parent? && category.parent.has_parent?
+          - if @item.category.has_parent? && @item.category.parent.has_parent?
             %div=link_to "#{@item.category.parent.parent.name}", category_path(@item.category.parent.parent.id)
           - if @item.category.has_parent?
             %div=link_to "#{@item.category.parent.name}", category_path(@item.category.parent.id)


### PR DESCRIPTION
# What
categories#showのサーバーサイドを編集し、登録された商品がその親カテゴリのカテゴリー詳細画面にも表示されるようにする。
# Why
現在は当該カテゴリにしか表示されておらず、親カテゴリでも表示されるのが適切であるため。