### PR TITLE
category.jsへのturbolinksの導入

### DIFF
--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,4 +1,4 @@
-$(function() {
+$(document).on('turbolinks:load', function(){
   //ヘッダーのカテゴリー表示
   function appendParentCategory(category){
     let html = `<a href="/categories/${category.id}" class="parent_nav_list" data-parent_id="${category.id}">${category.name}</a>`


### PR DESCRIPTION
# What
category.jsにturbolinksを導入する
# Why
ヘッダーのカテゴリボタンにカーソルを合わせた際、javascriptが再読み込みされず、カテゴリ選択が表示されない問題を解消するため