### PR TITLE
売却済み商品を表示する際の詳細画面の修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -52,35 +52,36 @@
         = icon "fas", "flag", class: "reportIcon"
         %p 不適切な商品の通報
 
-  - if current_user && current_user.id == @item.user.id
-    .editorBox
-      -# %p.editorBox__headline 出品者編集
-      .editorBox__btnBox
-        = link_to "商品情報編集", edit_item_path, class: "editorBtn edit"
-        = link_to "出品取消", "#", class: "editorBtn delete", method: :delete
-  - else
-    .purchaseBox
-      = link_to "購入する", buy_item_path(@item.id), class: "purchaseBtn"
+  - if @item.status_id == 1
+    - if current_user && current_user.id == @item.user.id
+      .editorBox
+        -# %p.editorBox__headline 出品者編集
+        .editorBox__btnBox
+          = link_to "商品情報編集", edit_item_path, class: "editorBtn edit"
+          = link_to "出品取消", "#", class: "editorBtn delete", method: :delete
+    - else
+      .purchaseBox
+        = link_to "購入する", buy_item_path(@item.id), class: "purchaseBtn"
 
-  .commentBox
-    = form_with url: "#", class: "commentForm" do |f|
-      = f.text_area :content, class: "commentForm__content", rows: "5"
-      %p.commentForm__attention 
-        相手のことを考え丁寧なコメントを心がけましょう。
-        %br 不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      %label
-        = f.submit "送信", class: "commentForm__submitBtn"
-        .commentForm__btnLooking
-          = icon "fas", "comment", class: "speechBubbleIcon"
-          %p コメントする
-  .fowardAndNextBtnBox
-    - if (@items.index(@item)-1) >= 0
-      = link_to "〈 前の商品", item_path(@items[(@items.index(@item))-1].id), class: "fowardAndNextBtnBox__fowardBtn"
-    - if @items[(@items.index(@item))+1]
-      = link_to "後ろの商品 〉", item_path(@items[(@items.index(@item))+1].id), class: "fowardAndNextBtnBox__nextBtn"
-  .moreItemsShowBox
-    = link_to "#{@item.category.name}をもっと見る", category_path(@item.category_id), class: "moreItemsShowBox__headline"
-    .moreItemsShowBox__itemList
-      = render partial: "items_list", collection: @more_items, as: "item"
+    .commentBox
+      = form_with url: "#", class: "commentForm" do |f|
+        = f.text_area :content, class: "commentForm__content", rows: "5"
+        %p.commentForm__attention 
+          相手のことを考え丁寧なコメントを心がけましょう。
+          %br 不快な言葉遣いなどは利用制限や退会処分となることがあります。
+        %label
+          = f.submit "送信", class: "commentForm__submitBtn"
+          .commentForm__btnLooking
+            = icon "fas", "comment", class: "speechBubbleIcon"
+            %p コメントする
+    .fowardAndNextBtnBox
+      - if (@items.index(@item)-1) >= 0
+        = link_to "〈 前の商品", item_path(@items[(@items.index(@item))-1].id), class: "fowardAndNextBtnBox__fowardBtn"
+      - if @items[(@items.index(@item))+1]
+        = link_to "後ろの商品 〉", item_path(@items[(@items.index(@item))+1].id), class: "fowardAndNextBtnBox__nextBtn"
+    .moreItemsShowBox
+      = link_to "#{@item.category.name}をもっと見る", category_path(@item.category_id), class: "moreItemsShowBox__headline"
+      .moreItemsShowBox__itemList
+        = render partial: "items_list", collection: @more_items, as: "item"
 
 = render partial: "footer"


### PR DESCRIPTION
# What
商品詳細ページのビューを編集する
# Why
売却済み商品を表示する際にエラーが発生していたため、status_idが2の場合のif文を追加しエラーを回避する